### PR TITLE
FindHighlight color added

### DIFF
--- a/dracula.vssettings
+++ b/dracula.vssettings
@@ -65,6 +65,7 @@
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00C679FF" Name="XML Doc Tag" />
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00A47262" Name="XML Doc Comment" />
               <Item Background="0x005A4744" BoldFont="No" Foreground="0x02000000" Name="MarkerFormatDefinition/HighlightedReference" />
+              <Item Background="0x00FF00FF" BoldFont="No" Foreground="0x02000000" Name="MarkerFormatDefinition/FindHighlight" />
               <Item Background="0x02000000" BoldFont="No" Foreground="0x008CFAF1" Name="urlformat" />
               <Item Background="0x00957873" BoldFont="No" Foreground="0x02000000" Name="CurrentLineActiveFormat" />
               <Item Background="0x00E2E2E2" BoldFont="No" Foreground="0x00555555" Name="outlining.square" />


### PR DESCRIPTION
Current FindHighlight color resembles with breakpoint color (brown), which results in similar indicator on scrollbar. So, I've assigned Magenta color (to make it noticeable on scrollbar). [see attached images]

Before changes (Current Setting):
![BeforeChanges](https://user-images.githubusercontent.com/23517648/33231221-aeef747c-d219-11e7-9505-b516025be2b0.PNG)

After changes:
![AfterChanges](https://user-images.githubusercontent.com/23517648/33231222-b14907ba-d219-11e7-936a-33da11f95c11.PNG)
