### PR TITLE
Re-added missing C++ settings for 2017

### DIFF
--- a/dracula.vssettings
+++ b/dracula.vssettings
@@ -107,6 +107,18 @@
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="delegate name" />
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="class name" />
               <Item Background="0x02000000" BoldFont="No" Foreground="0x008CFAF1" Name="string - verbatim" />
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CppMacroSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppEnumSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppGlobalVariableSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppLocalVariableSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppParameterSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="CppTypeSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CppFunctionSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CppMemberFunctionSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppMemberFieldSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CppStaticMemberFunctionSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppStaticMemberFieldSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppNamespaceSemanticTokenFormat"/>
             </Items>
           </Category>
           <Category FontIsDefault="Yes" GUID="{58E96763-1D3B-4E05-B6BA-FF7115FD0B7B}">


### PR DESCRIPTION
The C++ theme settings for 2017 were omitted in 77b149872375253306fe0c6e7098b3670b1c31cf. This fix restores them.

Before the fix: 
![image](https://user-images.githubusercontent.com/1720681/37248357-5f50018e-249e-11e8-87c9-a2a051896213.png)

After the fix:
![image](https://user-images.githubusercontent.com/1720681/37248360-6a01f286-249e-11e8-8bb2-f210c4ccec7e.png)
