### PR TITLE
added basic css and scss styling

### DIFF
--- a/dracula.vssettings
+++ b/dracula.vssettings
@@ -120,6 +120,16 @@
               <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CppStaticMemberFunctionSemanticTokenFormat"/>
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppStaticMemberFieldSemanticTokenFormat"/>
               <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="CppNamespaceSemanticTokenFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="ScssMixinReferenceFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="ScssMixinDeclarationFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F2F8F8" Name="ScssVariableReferenceFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00C679FF" Name="ScssVariableDeclarationClassificationFormat"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x008CFAF1" Name="CSS String Value"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00F993BD" Name="CSS Property Value"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00FDE98B" Name="CSS Property Name"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x007BFA50" Name="CSS Selector"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00C679FF" Name="CSS Keyword"/>
+              <Item Background="0x02000000" BoldFont="No" Foreground="0x00A47262" Name="CSS Comment"/>
             </Items>
           </Category>
           <Category FontIsDefault="Yes" GUID="{58E96763-1D3B-4E05-B6BA-FF7115FD0B7B}">


### PR DESCRIPTION
Seems like syntax highlighting for CSS and SCSS was missing. I added some basic styling, but the possibilities in Visual Studio are kind of limited in this area. So: Far from being perfect, but better than before.

Before:
![anmerkung 2019-02-12 144006](https://user-images.githubusercontent.com/5961473/52639282-334adf00-2ed4-11e9-94d1-76cc58933b7d.jpg)

Now:
![anmerkung 2019-02-12 101753](https://user-images.githubusercontent.com/5961473/52639291-38a82980-2ed4-11e9-9a78-be113da4f298.jpg)

And one CSS-only example:
![anmerkung 2019-02-12 102205](https://user-images.githubusercontent.com/5961473/52639337-4fe71700-2ed4-11e9-9749-eb569163a3a4.jpg)


